### PR TITLE
Add recorder server launch and entry points

### DIFF
--- a/launch/recorder_server.launch.py
+++ b/launch/recorder_server.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+import os
+
+def generate_launch_description():
+    share = get_package_share_directory('rosetta')
+    contract = os.path.join(share, 'contracts', 'example.yaml')
+    return LaunchDescription([
+        Node(
+            package='rosetta',
+            executable='recorder_server',
+            name='recorder_server',
+            output='screen',
+            emulate_tty=True,
+            parameters=[{'contract_path': contract}],
+        ),
+    ])

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import find_packages, setup
+from glob import glob
+import os
 
 package_name = 'rosetta'
 
@@ -10,6 +12,8 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
+        (os.path.join('share', package_name, 'contracts'), glob('contracts/*.yaml')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
@@ -20,6 +24,8 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'policy_bridge = rosetta.policy_bridge_node:main',
+            'recorder_server = rosetta.episode_recorder:main',
         ],
     },
 )


### PR DESCRIPTION
## Summary
- add missing recorder server launch script
- install launch and contract files and expose console scripts

## Testing
- `pytest -q` *(fails: No module named 'ament_copyright')*


------
https://chatgpt.com/codex/tasks/task_b_68c736a6ce70832f8c47a7b0c17276d3