### PR TITLE
Provide rad2deg conversion.

### DIFF
--- a/contracts/so_101.yaml
+++ b/contracts/so_101.yaml
@@ -11,7 +11,7 @@ observations:
       resize: [512, 512]
     align: {strategy: hold, stamp: header}
     qos: {reliability: best_effort, history: keep_last, depth: 10}
-  
+
   - key: observation.images.top
     topic: /top_camera/image_raw/compressed
     type: sensor_msgs/msg/CompressedImage
@@ -35,6 +35,7 @@ observations:
       names: [position.shoulder_pan, position.shoulder_lift, position.elbow, position.wrist_pitch, position.wrist_roll, position.wrist_yaw]
     align: {strategy: hold, stamp: header}
     qos: {reliability: best_effort, history: keep_last, depth: 50}
+    unit_conversion: rad2deg
 
 actions:
   - key: action
@@ -44,6 +45,7 @@ actions:
       qos: {reliability: best_effort, history: keep_last, depth: 10}
     selector:
       names: [position.shoulder_pan, position.shoulder_lift, position.elbow, position.wrist_pitch, position.wrist_roll, position.wrist_yaw]
+    unit_conversion: rad2deg
 
 recording:
   storage: mcap

--- a/rosetta/common/contract_utils.py
+++ b/rosetta/common/contract_utils.py
@@ -359,6 +359,7 @@ def iter_observation_specs(contract: Contract) -> Iterable[ObservationStreamSpec
             dtype=dtype,
             qos=o.qos,
             decoder=o.decoder,
+            unit_conversion=o.unit_conversion,
         )
         items.append((o.topic, kwargs, o))
 
@@ -397,6 +398,7 @@ def iter_action_specs(contract: Contract) -> Iterable[ActionStreamSpec]:
             qos=a.publish_qos,
             decoder=a.decoder,
             encoder=a.encoder,
+            unit_conversion=a.unit_conversion,
         )
         items.append((a.publish_topic, kwargs, a))
 
@@ -434,6 +436,7 @@ def iter_extended_specs(contract: Contract) -> Iterable[ObservationStreamSpec]:
                 qos=o.qos,
                 namespace=None,
                 decoder=o.decoder,
+                unit_conversion=o.unit_conversion,
             )
 
 
@@ -489,6 +492,7 @@ def iter_teleop_input_specs(contract: Contract) -> Iterable[ObservationStreamSpe
             dtype=dtype,
             qos=o.qos,
             decoder=o.decoder,
+            unit_conversion=o.unit_conversion,
         )
         items.append((o.topic, kwargs, o))
 
@@ -521,6 +525,7 @@ def iter_teleop_feedback_specs(contract: Contract) -> Iterable[ActionStreamSpec]
             qos=a.publish_qos,
             decoder=a.decoder,
             encoder=a.encoder,
+            unit_conversion=a.unit_conversion,
         )
         items.append((a.publish_topic, kwargs, a))
 


### PR DESCRIPTION
### Context

- ROS convention relies radians
- LeRobot dataset uses degrees (or [normalized to motor](https://github.com/huggingface/lerobot/blob/35363c5798d129d7667c2efa43ddfa342639a35a/src/lerobot/motors/motors_bus.py#L158-L161))

### Summary
- Add unit_conversion field to the contract for both action and observation
  - Only available option is rad2deg

- dataflow:
   - If `rad2deg` is used:
      - when doing the conversion to lerobot the data (both observations and actions) is translated to degrees
      - when running inference the actions coming from the policy are converted from degrees to rad (inverse) for correct use.
  